### PR TITLE
Fix pump station LoRa message handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Example ESPHome configuration for a LoRa based pump controller. Two Heltec WiFi LoRa 32 V3 boards communicate over LoRa using the [lora_sx126x](https://github.com/PaulSchulz/esphome-lora-sx126x) external component.
 
 - `pump_controller.yaml` sends on/off commands.
-- `pump_station.yaml` listens for those commands and toggles a relay.
+- `pump_station.yaml` listens for those commands via a text sensor and toggles a relay.
 
 Both YAML files require WiFi credentials and API/OTA secrets via the standard ESPHome `secrets.yaml` mechanism. LoRa pins are configured for the Heltec V3 board.
 

--- a/esphome/pump_station.yaml
+++ b/esphome/pump_station.yaml
@@ -49,15 +49,18 @@ sensor:
     id: lora_rssi
     name: "LoRa RSSI"
 
-binary_sensor:
+text_sensor:
   - platform: lora_sx126x
     id: pump_cmd
-    on_string: "PUMP_ON"
-    off_string: "PUMP_OFF"
-    on_press:
-      - switch.turn_on: pump_relay
-    on_release:
-      - switch.turn_off: pump_relay
+    name: "Pump Command"
+    on_value:
+      then:
+        - lambda: |-
+            if (x == "PUMP_ON") {
+              id(pump_relay).turn_on();
+            } else if (x == "PUMP_OFF") {
+              id(pump_relay).turn_off();
+            }
 
 switch:
   - platform: gpio


### PR DESCRIPTION
## Summary
- use `text_sensor` to receive LoRa messages
- document text-sensor based receiver in README

## Testing
- `esphome compile esphome/pump_station.yaml` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687125dfbd94832b940a3493ce0c2360