### PR TITLE
Add controller and receiver PlatformIO code

### DIFF
--- a/pump-controller/platformio.ini
+++ b/pump-controller/platformio.ini
@@ -1,14 +1,18 @@
-; PlatformIO Project Configuration File
-;
-;   Build options: build flags, source filter
-;   Upload options: custom upload port, speed and extra flags
-;   Library options: dependencies, extra library storages
-;   Advanced options: extra scripting
-;
-; Please visit documentation for the other options and examples
-; https://docs.platformio.org/page/projectconf.html
-
-[env:heltec_wifi_lora_32_V3]
+[env:controller]
 platform = espressif32
 board = heltec_wifi_lora_32_V3
-framework = espidf
+framework = arduino
+monitor_speed = 115200
+lib_deps =
+    https://github.com/HelTecAutomation/Heltec_ESP32
+    knolleary/PubSubClient
+src_dir = src/controller
+
+[env:receiver]
+platform = espressif32
+board = heltec_wifi_lora_32_V3
+framework = arduino
+monitor_speed = 115200
+lib_deps =
+    https://github.com/HelTecAutomation/Heltec_ESP32
+src_dir = src/receiver

--- a/pump-controller/src/controller/main.cpp
+++ b/pump-controller/src/controller/main.cpp
@@ -1,0 +1,85 @@
+#include <heltec.h>
+#include <WiFi.h>
+#include <PubSubClient.h>
+
+const char *ssid = "YOUR_WIFI";
+const char *password = "YOUR_PASS";
+const char *mqtt_server = "192.168.1.10";
+
+WiFiClient espClient;
+PubSubClient mqttClient(espClient);
+
+static bool pumpOn = false;
+
+void updateDisplay() {
+    Heltec.display->clear();
+    Heltec.display->drawString(0, 0, pumpOn ? "Pump ON" : "Pump OFF");
+    Heltec.display->display();
+}
+
+void publishState() {
+    mqttClient.publish("pump_controller/switch/state", pumpOn ? "ON" : "OFF", true);
+    updateDisplay();
+}
+
+void sendLoRa(const char *msg) {
+    Heltec.LoRa.beginPacket();
+    Heltec.LoRa.print(msg);
+    Heltec.LoRa.endPacket();
+}
+
+void mqttCallback(char *topic, byte *payload, unsigned int length) {
+    String cmd;
+    for (unsigned int i = 0; i < length; i++) {
+        cmd += (char)payload[i];
+    }
+    if (cmd == "ON") {
+        pumpOn = true;
+        sendLoRa("ON");
+    } else if (cmd == "OFF") {
+        pumpOn = false;
+        sendLoRa("OFF");
+    }
+    publishState();
+}
+
+void sendDiscovery() {
+    const char *discoveryTopic = "homeassistant/switch/pump_controller/config";
+    String payload = "{\"name\":\"Pump\",\"command_topic\":\"pump_controller/switch/set\",\"state_topic\":\"pump_controller/switch/state\",\"payload_on\":\"ON\",\"payload_off\":\"OFF\",\"unique_id\":\"pump_controller\",\"device\":{\"identifiers\":[\"pump_controller\"],\"name\":\"Pump Controller\",\"model\":\"Heltec WiFi LoRa 32 V3\",\"manufacturer\":\"Heltec\"}}";
+    mqttClient.publish(discoveryTopic, payload.c_str(), true);
+}
+
+void ensureMqtt() {
+    while (!mqttClient.connected()) {
+        mqttClient.connect("pump_controller");
+        if (!mqttClient.connected()) {
+            delay(500);
+        }
+    }
+    mqttClient.subscribe("pump_controller/switch/set");
+}
+
+void setup() {
+    Heltec.begin(true, true, true, true);
+    updateDisplay();
+
+    WiFi.begin(ssid, password);
+    while (WiFi.status() != WL_CONNECTED) {
+        delay(500);
+    }
+
+    mqttClient.setServer(mqtt_server, 1883);
+    mqttClient.setCallback(mqttCallback);
+
+    ensureMqtt();
+    sendDiscovery();
+    publishState();
+}
+
+void loop() {
+    if (!mqttClient.connected()) {
+        ensureMqtt();
+    }
+    mqttClient.loop();
+}
+

--- a/pump-controller/src/receiver/main.cpp
+++ b/pump-controller/src/receiver/main.cpp
@@ -1,0 +1,37 @@
+#include <heltec.h>
+
+const int PUMP_PIN = 2; // example GPIO
+static bool pumpOn = false;
+
+void updateDisplay() {
+    Heltec.display->clear();
+    Heltec.display->drawString(0, 0, pumpOn ? "Pump ON" : "Pump OFF");
+    Heltec.display->display();
+}
+
+void setPump(bool on) {
+    pumpOn = on;
+    digitalWrite(PUMP_PIN, on ? HIGH : LOW);
+    updateDisplay();
+}
+
+void setup() {
+    pinMode(PUMP_PIN, OUTPUT);
+    Heltec.begin(true, true, true, true);
+    updateDisplay();
+}
+
+void loop() {
+    int size = Heltec.LoRa.parsePacket();
+    if (size) {
+        String cmd;
+        while (Heltec.LoRa.available()) {
+            cmd += (char)Heltec.LoRa.read();
+        }
+        if (cmd == "ON") {
+            setPump(true);
+        } else if (cmd == "OFF") {
+            setPump(false);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add PlatformIO environments for controller and receiver
- implement controller to send HA discovery messages and LoRa commands
- implement receiver to toggle pump via LoRa

## Testing
- `platformio run -e controller` *(fails: HTTPClientError due to blocked network access)*
- `platformio run -e receiver` *(fails: HTTPClientError due to blocked network access)*

------
https://chatgpt.com/codex/tasks/task_e_68724494faa4832bb4da0478c664c0d4