### PR TITLE
Switch Heltec library

### DIFF
--- a/pump-controller/platformio.ini
+++ b/pump-controller/platformio.ini
@@ -4,7 +4,8 @@ board = heltec_wifi_lora_32_V3
 framework = arduino
 monitor_speed = 115200
 lib_deps =
-    https://github.com/HelTecAutomation/Heltec_ESP32
+    https://github.com/eiannone/Heltec_Esp32_LoRaWan.git
+    https://github.com/eiannone/Heltec_Esp32_Display.git
     adafruit/Adafruit GFX Library@^1.12.1
     knolleary/PubSubClient
 src_dir = src/controller
@@ -17,7 +18,8 @@ board = heltec_wifi_lora_32_V3
 framework = arduino
 monitor_speed = 115200
 lib_deps =
-    https://github.com/HelTecAutomation/Heltec_ESP32
+    https://github.com/eiannone/Heltec_Esp32_LoRaWan.git
+    https://github.com/eiannone/Heltec_Esp32_Display.git
     adafruit/Adafruit GFX Library@^1.12.1
 src_dir = src/receiver
 build_flags =


### PR DESCRIPTION
## Summary
- switch to eiannone Heltec libraries in PlatformIO config

## Testing
- `platformio run` *(fails: api.registry.platformio.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6872522cf3b8832bbcd2ac8e387fdc83