### PR TITLE
Improve display status information

### DIFF
--- a/pump-controller/src/controller.cpp
+++ b/pump-controller/src/controller.cpp
@@ -66,10 +66,15 @@ void Controller::updateDisplay()
     mDisplay.display.setTextSize(1); // Draw 2X-scale text
 
     mDisplay.display.setCursor(10, 22);
-    mDisplay.display.printf("LM: %s", mLastMessage.substring(0, 12).c_str());
+    mDisplay.display.printf("Pending: %s", relayStateToString(requestedRelayState));
 
+    bool awaitingAck = relayState != requestedRelayState;
+    const char *status = lora_idle ? "IDLE" : "TX";
+    if (awaitingAck) {
+        status = "WAIT ACK";
+    }
     mDisplay.display.setCursor(10, 36);
-    mDisplay.display.printf("SIZE: %d", mLastMessageSize);
+    mDisplay.display.printf("Status: %s", status);
 
     mDisplay.display.setCursor(10, 50);
     mDisplay.display.printf("RSSI: %d SNR: %d", mLastRssi, mLastSnr);

--- a/pump-controller/src/receiver.cpp
+++ b/pump-controller/src/receiver.cpp
@@ -57,10 +57,10 @@ void Receiver::updateDisplay()
     mDisplay.display.setTextSize(1); // Draw 2X-scale text
 
     mDisplay.display.setCursor(10, 22);
-    mDisplay.display.printf("LM: %s", mLastMessage.substring(0, 12).c_str());
+    mDisplay.display.printf("Ack: %s", ackConfirmed ? "OK" : "WAIT");
 
     mDisplay.display.setCursor(10, 36);
-    mDisplay.display.printf("SIZE: %d", mLastMessageSize);
+    mDisplay.display.printf("Pend Acks: %d", acksRemaining);
 
     mDisplay.display.setCursor(10, 50);
     mDisplay.display.printf("RSSI: %d SNR: %d", mLastRssi, mLastSnr);


### PR DESCRIPTION
## Summary
- enhance controller status display by showing pending relay state and ACK status
- show ack information on receiver display

## Testing
- `pio run` *(fails: MQTT_* and WIFI_* constants missing in config.h)*

------
https://chatgpt.com/codex/tasks/task_e_68747ba6bd98832b89bbaa608b8e176d