### PR TITLE
Add auto-off timer and keepalive

### DIFF
--- a/pump-controller/include/controller.h
+++ b/pump-controller/include/controller.h
@@ -7,6 +7,7 @@
 
 #include "device.h"
 #include "display.h"
+#include "device-config.h"
 
 enum RelayState
 {
@@ -55,9 +56,10 @@ private:
     void updateDisplay();
     void sendMessage(const char *msg);
     void sendAckReceived(uint16_t stateId);
-    void setRelayState(bool pumpOn);
+    void setRelayState(bool pumpOn, unsigned int onTime = DEFAULT_ON_TIME_SEC);
 
-    unsigned long lastSend = 0;
+    unsigned long nextOnSend = 0;
+    unsigned int onTimeSec = DEFAULT_ON_TIME_SEC;
 
     // unsigned int messageNumnber = 0;
     void publishState();

--- a/pump-controller/include/device-config.h
+++ b/pump-controller/include/device-config.h
@@ -34,4 +34,8 @@
 #define RX_TIMEOUT_VALUE                            1000
 #define BUFFER_SIZE                                 30 // Define the payload size here
 
+// Default number of seconds the receiver will remain ON if
+// no further ON commands are received.
+#define DEFAULT_ON_TIME_SEC                         180
+
 #endif

--- a/pump-controller/include/receiver.h
+++ b/pump-controller/include/receiver.h
@@ -3,6 +3,7 @@
 
 #include "device.h"
 #include "display.h"
+#include "device-config.h"
 
 class Receiver : public Device
 {
@@ -26,6 +27,8 @@ class Receiver : public Device
     int16_t mLastRssi;
     int8_t mLastSnr;
     bool mRelayState;
+    unsigned long offTime = 0;
+    unsigned int onTimeSec = DEFAULT_ON_TIME_SEC;
     int acksRemaining;
     uint16_t ackStateId;
     bool ackConfirmed;


### PR DESCRIPTION
## Summary
- define DEFAULT_ON_TIME_SEC for receiver timeout
- track ON duration and next send time for controller/receiver
- resend ON messages periodically
- auto turn off receiver after timeout
- parse duration from ON MQTT messages
- show timing info on displays

## Testing
- `platformio run` *(fails: WIFI/MQTT configs missing)*

------
https://chatgpt.com/codex/tasks/task_e_687484097188832ba914f654a626add6