### PR TITLE
Add pulse MQTT discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,10 @@ Flash the compiled firmware to two boards. Set `isController` as required before
 
 - `pump_station/switch/set` – payload `ON[:seconds]` or `OFF` to control the relay. If `seconds` is omitted the controller uses `DEFAULT_ON_TIME_SEC`.
 - `pump_station/switch/pulse` – payload is a number of seconds to turn the relay on once. The controller automatically sends `OFF` after the duration and no heartbeat messages are sent.
+
+### Home Assistant Discovery
+
+The controller publishes MQTT discovery messages for easy integration with Home Assistant.
+It exposes a `switch` entity for basic on/off control and a `number` entity named
+`Pump Pulse` that publishes its value to `pump_station/switch/pulse` whenever the
+number is changed. The number represents the pulse duration in seconds.

--- a/pump-controller/src/controller.cpp
+++ b/pump-controller/src/controller.cpp
@@ -139,9 +139,13 @@ void Controller::mqttCallback(char *topic, byte *payload, unsigned int length) {
     "}"
 
 void Controller::sendDiscovery() {
-    const char *discoveryTopic = "homeassistant/switch/pump_station/config";
-    String payload = "{\"name\":\"Pump\",\"command_topic\":\"pump_station/switch/set\",\"state_topic\":\"pump_station/switch/state\",\"payload_on\":\"ON\",\"payload_off\":\"OFF\",\"unique_id\":\"pump_station\",\"device\":{\"identifiers\":[\"pump_station\"],\"name\":\"Pump Controller\",\"model\":\"Heltec WiFi LoRa 32 V3\",\"manufacturer\":\"Heltec\"}}";
-    mqttClient.publish(discoveryTopic, payload.c_str(), true);
+    const char *switchTopic = "homeassistant/switch/pump_station/config";
+    const char *switchPayload = "{\"name\":\"Pump\",\"command_topic\":\"pump_station/switch/set\",\"state_topic\":\"pump_station/switch/state\",\"payload_on\":\"ON\",\"payload_off\":\"OFF\",\"unique_id\":\"pump_station\",\"device\":{\"identifiers\":[\"pump_station\"],\"name\":\"Pump Controller\",\"model\":\"Heltec WiFi LoRa 32 V3\",\"manufacturer\":\"Heltec\"}}";
+    mqttClient.publish(switchTopic, switchPayload, true);
+
+    const char *pulseTopic = "homeassistant/number/pump_station_pulse/config";
+    const char *pulsePayload = "{\"name\":\"Pump Pulse\",\"command_topic\":\"pump_station/switch/pulse\",\"min\":1,\"max\":3600,\"step\":1,\"unit_of_measurement\":\"s\",\"unique_id\":\"pump_station_pulse\",\"device\":{\"identifiers\":[\"pump_station\"],\"name\":\"Pump Controller\",\"model\":\"Heltec WiFi LoRa 32 V3\",\"manufacturer\":\"Heltec\"}}";
+    mqttClient.publish(pulseTopic, pulsePayload, true);
 }
 
 


### PR DESCRIPTION
## Summary
- include a Home Assistant number entity in MQTT discovery so the `pulse` topic is exposed
- document the new discovery info in the README

## Testing
- `pio run` *(fails: `WIFI_SSID`/`MQTT_USER` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6874a464a114832b85d6c9a08ee5703e