### PR TITLE
Improve pulse message handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Flash the compiled firmware to two boards. Set `isController` as required before
 ### MQTT Topics
 
 - `pump_station/switch/set` – payload `ON[:seconds]` or `OFF` to control the relay. If `seconds` is omitted the controller uses `DEFAULT_ON_TIME_SEC`.
-- `pump_station/switch/pulse` – payload is a number of seconds to turn the relay on once. The controller automatically sends `OFF` after the duration and no heartbeat messages are sent.
+- `pump_station/switch/pulse` – payload is a number of seconds to turn the relay on once. The controller sends a `PULSE` LoRa message containing the duration and also publishes an `OFF` message when the time expires.
 
 ### Home Assistant Discovery
 

--- a/pump-controller/include/controller.h
+++ b/pump-controller/include/controller.h
@@ -56,7 +56,7 @@ private:
     void updateDisplay();
     void sendMessage(const char *msg);
     void sendAckReceived(uint16_t stateId);
-    void setRelayState(bool pumpOn, unsigned int onTime = DEFAULT_ON_TIME_SEC);
+    void setRelayState(bool pumpOn, unsigned int onTime = DEFAULT_ON_TIME_SEC, bool pulse = false);
     void pulseRelay(unsigned int onTime);
 
     unsigned long nextOnSend = 0;

--- a/pump-controller/src/controller.cpp
+++ b/pump-controller/src/controller.cpp
@@ -271,7 +271,7 @@ void Controller::sendAckReceived(uint16_t stateId)
 }
 
 
-void Controller::setRelayState(bool pumpOn, unsigned int onTime)
+void Controller::setRelayState(bool pumpOn, unsigned int onTime, bool pulse)
 {
   ++mStateId;
   requestedRelayState = pumpOn ? RelayState::ON : RelayState::OFF;
@@ -282,8 +282,12 @@ void Controller::setRelayState(bool pumpOn, unsigned int onTime)
 
   char msg[32];
   if(pumpOn) {
-      sprintf(msg, "ON:%u", onTimeSec);
-      nextOnSend = millis();
+      if(pulse) {
+          sprintf(msg, "PULSE:%u", onTimeSec);
+      } else {
+          sprintf(msg, "ON:%u", onTimeSec);
+          nextOnSend = millis();
+      }
   } else {
       sprintf(msg, "OFF");
   }
@@ -295,7 +299,7 @@ void Controller::pulseRelay(unsigned int onTime)
 {
     heartbeatEnabled = false;
     autoOffTime = millis() + (unsigned long)onTime * 1000UL;
-    setRelayState(true, onTime);
+    setRelayState(true, onTime, true);
 }
 
 

--- a/pump-controller/src/receiver.cpp
+++ b/pump-controller/src/receiver.cpp
@@ -243,12 +243,13 @@ void Receiver::processReceived(char *rxpacket)
     else if (index >= 3 && strlen(strings[0]) == 1 && strings[0][0] == 'C')
     {
         uint16_t stateId = atoi(strings[1]);
-        bool newRelayState = strcasecmp(strings[2], "on") == 0;
+        bool newRelayState = false;
+        if(strcasecmp(strings[2], "on") == 0 || strcasecmp(strings[2], "pulse") == 0) {
+            newRelayState = true;
+        }
         if(newRelayState && index >= 4) {
             onTimeSec = atoi(strings[3]);
         } else if(newRelayState) {
-            // If no duration is provided, default to 0 seconds which will
-            // cause the relay to turn off immediately.
             onTimeSec = 0;
         }
         setRelayState(newRelayState);


### PR DESCRIPTION
## Summary
- encode pulse duration in LoRa message so receivers auto-off
- document behaviour in README

## Testing
- `pip install platformio`
- `pio run`

------
https://chatgpt.com/codex/tasks/task_e_6874a7570734832bb1863a71b2214ba5