### PR TITLE
Add receiver hello and config persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,9 @@ The controller publishes MQTT discovery messages for easy integration with Home 
 It exposes a `switch` entity for basic on/off control and `number` entities named
 `Pump Pulse`, `Controller Tx Power` and `Receiver Tx Power`.
 The controller enforces a minimum transmit power defined by `MIN_TX_OUTPUT_POWER`.
+
+On boot the controller sends a `STATUS` request to the receiver. The receiver
+responds with a `HELLO` message containing its current configuration (currently
+just transmit power). If the values differ from those the controller has
+persisted from previous MQTT commands it will resend the appropriate
+configuration messages.

--- a/pump-controller/include/controller.h
+++ b/pump-controller/include/controller.h
@@ -50,6 +50,7 @@ private:
 
     double txNumber;
     int txPower = TX_OUTPUT_POWER;
+    int receiverTxPower = TX_OUTPUT_POWER;
 
     bool lora_idle = true;
 

--- a/pump-controller/include/receiver.h
+++ b/pump-controller/include/receiver.h
@@ -23,6 +23,7 @@ class Receiver : public Device
     unsigned int getSendStatusFrequency() const { return statusSendFreqSec; }
 
     private:
+    void sendHello();
     void updateDisplay();
     void setIdle();
     bool mWifiEnabled=false;


### PR DESCRIPTION
## Summary
- store receiver TX power on the controller
- request status from receiver on controller boot
- make receiver respond with a `HELLO` message including its TX power
- resend configuration if values differ
- document new startup handshake

## Testing
- `pio run`

------
https://chatgpt.com/codex/tasks/task_e_6874c09fe080832b982c0e9660adc94a