### PR TITLE
Add periodic status reporting

### DIFF
--- a/pump-controller/include/controller.h
+++ b/pump-controller/include/controller.h
@@ -65,14 +65,20 @@ private:
     void setRelayState(bool pumpOn, unsigned int onTime = DEFAULT_ON_TIME_SEC, bool pulse = false);
     void pulseRelay(unsigned int onTime);
 
+    void publishControllerStatus();
+    void publishReceiverStatus(int power, int rssi, int snr, bool relay, bool pulse, int battery);
+
     void setSendStatusFrequency(unsigned int freq);
     unsigned int getSendStatusFrequency() const { return statusSendFreqSec; }
 
     unsigned long nextOnSend = 0;
     unsigned int onTimeSec = DEFAULT_ON_TIME_SEC;
     unsigned int statusSendFreqSec = DEFAULT_STATUS_SEND_FREQ_SEC;
+    unsigned int receiverStatusFreqSec = DEFAULT_STATUS_SEND_FREQ_SEC;
     bool heartbeatEnabled = true;
     unsigned long autoOffTime = 0;
+    unsigned long lastStatusPublish = 0;
+    bool pulseMode = false;
 
     // unsigned int messageNumnber = 0;
     void publishState();

--- a/pump-controller/include/receiver.h
+++ b/pump-controller/include/receiver.h
@@ -22,6 +22,8 @@ class Receiver : public Device
     void setSendStatusFrequency(unsigned int freq);
     unsigned int getSendStatusFrequency() const { return statusSendFreqSec; }
 
+    void sendStatus();
+
     private:
     void sendHello();
     void updateDisplay();
@@ -34,6 +36,7 @@ class Receiver : public Device
     int16_t mLastRssi;
     int8_t mLastSnr;
     bool mRelayState;
+    bool mPulseMode = false;
     unsigned long offTime = 0;
     // Duration to keep the relay on. This value is provided by the
     // controller in the ON message.
@@ -43,6 +46,7 @@ class Receiver : public Device
     bool ackConfirmed;
     int txPower = TX_OUTPUT_POWER;
     unsigned int statusSendFreqSec = DEFAULT_STATUS_SEND_FREQ_SEC;
+    unsigned long lastStatusSend = 0;
     void sendAck(char *rxpacket);
     void setRelayState(bool newRelayState);
     void processReceived(char *rxpacket);


### PR DESCRIPTION
## Summary
- add MQTT subscriptions and message support for status reporting
- send status updates from receiver at configurable intervals
- publish controller and receiver status via MQTT

## Testing
- `platformio run`

------
https://chatgpt.com/codex/tasks/task_e_6874ce4d0904832bb0dc313b61b02d0a