### PR TITLE
Add HA status sensor discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Flash the compiled firmware to two boards. Set `isController` as required before
 The controller publishes MQTT discovery messages for easy integration with Home Assistant.
 It exposes a `switch` entity for basic on/off control and `number` entities named
 `Pump Pulse`, `Controller Tx Power` and `Receiver Tx Power`.
+It also publishes `sensor` entities `Controller Status` and `Receiver Status`
+which report the JSON data sent to `pump_station/status/controller` and
+`pump_station/status/receiver`.
 The controller enforces a minimum transmit power defined by `MIN_TX_OUTPUT_POWER`.
 
 On boot the controller sends a `STATUS` request to the receiver. The receiver

--- a/pump-controller/src/controller.cpp
+++ b/pump-controller/src/controller.cpp
@@ -202,6 +202,14 @@ void Controller::sendDiscovery() {
     const char *rxPowerTopic = "homeassistant/number/pump_station_rx_power/config";
     const char *rxPowerPayload = "{\"name\":\"Receiver Tx Power\",\"command_topic\":\"pump_station/tx_power/receiver/set\",\"min\":0,\"max\":22,\"step\":1,\"unit_of_measurement\":\"dBm\",\"unique_id\":\"pump_station_rx_power\",\"device\":{\"identifiers\":[\"pump_station\"],\"name\":\"Pump Controller\",\"model\":\"Heltec WiFi LoRa 32 V3\",\"manufacturer\":\"Heltec\"}}";
     mqttClient.publish(rxPowerTopic, rxPowerPayload, true);
+
+    const char *ctrlStatusTopic = "homeassistant/sensor/pump_station_ctrl_status/config";
+    const char *ctrlStatusPayload = "{\"name\":\"Controller Status\",\"state_topic\":\"pump_station/status/controller\",\"value_template\":\"{{ value_json.state }}\",\"json_attributes_topic\":\"pump_station/status/controller\",\"unique_id\":\"pump_station_ctrl_status\",\"device\":{\"identifiers\":[\"pump_station\"],\"name\":\"Pump Controller\",\"model\":\"Heltec WiFi LoRa 32 V3\",\"manufacturer\":\"Heltec\"}}";
+    mqttClient.publish(ctrlStatusTopic, ctrlStatusPayload, true);
+
+    const char *rxStatusTopic = "homeassistant/sensor/pump_station_rx_status/config";
+    const char *rxStatusPayload = "{\"name\":\"Receiver Status\",\"state_topic\":\"pump_station/status/receiver\",\"value_template\":\"{{ value_json.state }}\",\"json_attributes_topic\":\"pump_station/status/receiver\",\"unique_id\":\"pump_station_rx_status\",\"device\":{\"identifiers\":[\"pump_station\"],\"name\":\"Pump Controller\",\"model\":\"Heltec WiFi LoRa 32 V3\",\"manufacturer\":\"Heltec\"}}";
+    mqttClient.publish(rxStatusTopic, rxStatusPayload, true);
 }
 
 


### PR DESCRIPTION
## Summary
- publish discovery topics for new controller/receiver status sensors
- mention new sensors in README

## Testing
- `pio run` *(fails: `WIFI_SSID` not declared)*

------
https://chatgpt.com/codex/tasks/task_e_6874e1a332f4832bb3d93231690411e5