### PR TITLE
Handle retained set command on MQTT reconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,6 @@ responds with a `HELLO` message containing its current configuration (currently
 just transmit power). If the values differ from those the controller has
 persisted from previous MQTT commands it will resend the appropriate
 configuration messages.
+
+When the controller connects to MQTT it processes any retained command on
+`pump_station/switch/set` so the relay resumes the last requested state.

--- a/pump-controller/src/controller.cpp
+++ b/pump-controller/src/controller.cpp
@@ -257,6 +257,13 @@ void Controller::ensureMqtt() {
     mqttClient.subscribe("pump_station/tx_power/receiver/set");
     mqttClient.subscribe("pump_station/status_freq/controller/set");
     mqttClient.subscribe("pump_station/status_freq/receiver/set");
+
+    // Process any retained messages (such as the last set command)
+    unsigned long start = millis();
+    while (millis() - start < 500) {
+        mqttClient.loop();
+        delay(10);
+    }
 }
 
 void Controller::setup() {


### PR DESCRIPTION
## Summary
- ensure we process any retained messages after connecting to MQTT
- document that the controller processes retained set commands

## Testing
- `pio run` *(fails: WIFI_SSID, MQTT_SERVER not declared)*

------
https://chatgpt.com/codex/tasks/task_e_6875b9f77888832b8e87f5cde2153bad