### PR TITLE
Fix Heltec battery voltage calculation

### DIFF
--- a/pump-controller/src/battery.cpp
+++ b/pump-controller/src/battery.cpp
@@ -8,7 +8,19 @@ void Battery::setup() {
 
 int Battery::getPercentage() {
     int raw = analogRead(BATTERY_VOLTAGE_PIN);
-    float voltage = ((float)raw / 4095.0f) * 2.0f * 3.3f; // assume 2:1 divider
+    // Heltec WiFi LoRa 32 V3 uses a ~4.9:1 voltage divider on the VBAT pin.
+    // The raw ADC reading therefore needs to be scaled by this factor as well
+    // as the ADC reference voltage. Empirically the ADC tends to report a
+    // slightly lower voltage than measured with a multimeter so a small
+    // calibration factor is applied (see Heltec example code).
+
+    const float adcMaxVoltage = 3.3f;
+    const float adcResolution = 4095.0f; // 12‑bit ADC
+    const float dividerRatio = (390.0f + 100.0f) / 100.0f; // 390k/100k
+    const float calibration = 4.2f / 4.095f; // measured / reported
+
+    float voltage = ((float)raw / adcResolution) * adcMaxVoltage * dividerRatio * calibration;
+
     int percent = (int)((voltage - 3.2f) / (4.2f - 3.2f) * 100.0f);
     if(percent < 0) percent = 0;
     if(percent > 100) percent = 100;


### PR DESCRIPTION
## Summary
- compute correct battery voltage using Heltec's divider ratio
- apply calibration factor to ADC reading

## Testing
- `pio run -v` *(fails: `WIFI_SSID` not declared)*

------
https://chatgpt.com/codex/tasks/task_e_68789062b8ec832bb7a8083f772d0f20